### PR TITLE
Update dotnet

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -91,7 +91,7 @@ runs:
       with:
         url: "https://github.com/SteamRE/DepotDownloader/releases/download/DepotDownloader_2.4.6/depotdownloader-2.4.6.zip"
         target: "${{ github.action_path }}/depotdownloader/"
-    - run: "unzip ./depotdownloader-2.4.6.zip -d ./"
+    - run: "unzip -o ./depotdownloader-2.4.6.zip -d ./"
       working-directory: "${{ github.action_path }}/depotdownloader/"
       shell: bash
     - run: chmod +x $GITHUB_ACTION_PATH/job.sh

--- a/action.yml
+++ b/action.yml
@@ -82,7 +82,7 @@ runs:
     - name: "Setup dotnet"
       uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: "5.0.x"
+        dotnet-version: "6.0.x"
       env:
         DOTNET_NOLOGO: true
         DOTNET_CLI_TELEMETRY_OPTOUT: true


### PR DESCRIPTION
DepotDownloader 2.4.6 requieres dotNet 6. See https://github.com/SteamRE/DepotDownloader/commit/4e81487aee798cb833042b3ffd4613199c97a404